### PR TITLE
fix(ui): tabs reset to manual when changing package manager

### DIFF
--- a/components/code-tabs.tsx
+++ b/components/code-tabs.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import * as React from "react"
+
+import { useConfig } from "@/hooks/use-config"
+import { Tabs } from "@radix-ui/react-tabs"
+
+
+export function CodeTabs({ children }: React.ComponentProps<typeof Tabs>) {
+    const [config, setConfig] = useConfig()
+
+    const installationType = React.useMemo(() => {
+        return config.installationType || "cli"
+    }, [config])
+
+    return (
+        <Tabs
+            value={installationType}
+            onValueChange={(value) =>
+                setConfig({ ...config, installationType: value as "cli" | "manual" })
+            }
+            className="relative mt-6 w-full"
+        >
+            {children}
+        </Tabs>
+    )
+}

--- a/components/mdx-components.tsx
+++ b/components/mdx-components.tsx
@@ -29,6 +29,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { AspectRatio } from "@/components/ui/aspect-ratio"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Style } from "@/registry/registry-styles"
+import { CodeTabs } from "@/components/code-tabs"
 
 const components = {
   Accordion,
@@ -311,6 +312,7 @@ const components = {
       {...props}
     />
   ),
+  CodeTabs
 }
 
 interface MdxProps {

--- a/content/docs/components/animated-tooltip.mdx
+++ b/content/docs/components/animated-tooltip.mdx
@@ -10,7 +10,7 @@ description: A customizable animated tooltip component.
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+<CodeTabs>
 
 {" "}
 
@@ -106,7 +106,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/animated-tooltip.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 <Callout className="mb-6">
 

--- a/content/docs/components/button.mdx
+++ b/content/docs/components/button.mdx
@@ -8,7 +8,7 @@ description: The Button component you have here is a beautifully designed button
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -60,7 +60,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/button.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/carousel.mdx
+++ b/content/docs/components/carousel.mdx
@@ -10,7 +10,7 @@ description: A customizable Carousel component.
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 {" "}
 
@@ -103,7 +103,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/carousel.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 <Callout className="mb-6">
 

--- a/content/docs/components/copy-icon.mdx
+++ b/content/docs/components/copy-icon.mdx
@@ -10,7 +10,7 @@ description: When hovering over the clipboard icon, two hidden icons should move
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 {" "}
 
@@ -69,7 +69,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/copy-icon.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 ### Props
 

--- a/content/docs/components/custom-pointer.mdx
+++ b/content/docs/components/custom-pointer.mdx
@@ -10,7 +10,7 @@ links:
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -59,7 +59,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/custom-pointer.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ## Usage
 

--- a/content/docs/components/draggable-carousel.mdx
+++ b/content/docs/components/draggable-carousel.mdx
@@ -8,7 +8,7 @@ description: The DraggableCarousel component is a GSAP-powered animated carousel
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -61,7 +61,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/draggable-carousel.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/floating-navbar.mdx
+++ b/content/docs/components/floating-navbar.mdx
@@ -8,7 +8,7 @@ description: This component provides an elegant navigation menu with animated dr
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -61,6 +61,6 @@ npx shadcn@latest add https://ui.unizoy.com/r/floating-navbar.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 

--- a/content/docs/components/image-trail.mdx
+++ b/content/docs/components/image-trail.mdx
@@ -8,7 +8,7 @@ description: A dynamic and interactive React component that creates a trail of i
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -49,7 +49,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/image-trail.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/infinite-moving-cards.mdx
+++ b/content/docs/components/infinite-moving-cards.mdx
@@ -8,7 +8,7 @@ description: This InfiniteMovingCards component creates a continuously scrolling
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -49,7 +49,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/infinite-moving-cards.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/motion-cards.mdx
+++ b/content/docs/components/motion-cards.mdx
@@ -8,7 +8,7 @@ description: The MotionCard component is a GSAP-powered animated card layout tha
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -60,7 +60,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/motion-cards.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/navigation-icon.mdx
+++ b/content/docs/components/navigation-icon.mdx
@@ -10,7 +10,7 @@ description: When hovering over the navigation icon, the text should move upward
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 {" "}
 
@@ -71,7 +71,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/navigation-icon.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 ### Props
 

--- a/content/docs/components/product-preview.mdx
+++ b/content/docs/components/product-preview.mdx
@@ -8,7 +8,7 @@ description: Specification's animation around your product
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -60,7 +60,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/product-preview.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/reveal-text.mdx
+++ b/content/docs/components/reveal-text.mdx
@@ -9,7 +9,7 @@ description: A dynamic text component that reveals an image on hover with smooth
 />
 
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -56,7 +56,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/reveal-text.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ## Usage
 

--- a/content/docs/components/rotating-text.mdx
+++ b/content/docs/components/rotating-text.mdx
@@ -8,7 +8,7 @@ description: Rotation of texts while scaling at the same time.
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -60,7 +60,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/rotating-text.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/rythemic-reveal.mdx
+++ b/content/docs/components/rythemic-reveal.mdx
@@ -8,7 +8,7 @@ description: Slowly reveals the images in between the texts.
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -60,7 +60,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/rythemic-reveal.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/scaling-sliding-cards.mdx
+++ b/content/docs/components/scaling-sliding-cards.mdx
@@ -8,7 +8,7 @@ description: A dynamic scrolling component where images smoothly move from the r
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -55,7 +55,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/scaling-sliding-cards.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/scroll-opacity-effect.mdx
+++ b/content/docs/components/scroll-opacity-effect.mdx
@@ -8,7 +8,7 @@ description: Increasing the opacity of the whole text based on the scoll distanc
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -50,7 +50,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/scroll-opacity-effect.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 ### Props
 

--- a/content/docs/components/scroll-text-flow.mdx
+++ b/content/docs/components/scroll-text-flow.mdx
@@ -8,7 +8,7 @@ description: ScrollTextFlow is a React component that creates a dynamic scrollin
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -55,7 +55,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/scroll-text-flow.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/scrolling-cards.mdx
+++ b/content/docs/components/scrolling-cards.mdx
@@ -8,7 +8,7 @@ description: A dynamic, scroll-triggered component that creates an engaging card
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -57,7 +57,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/scrolling-cards.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ## Usage
 

--- a/content/docs/components/scrolling-video-cards.mdx
+++ b/content/docs/components/scrolling-video-cards.mdx
@@ -8,7 +8,7 @@ description: A dynamic scrolling component where videos smoothly moves horizonta
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -55,7 +55,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/scrolling-video-cards.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/sliding-cards.mdx
+++ b/content/docs/components/sliding-cards.mdx
@@ -8,7 +8,7 @@ description: A dynamic component that reveals hidden cards while scrolling.
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -99,7 +99,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/sliding-cards.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 ### Props
 

--- a/content/docs/components/testimonial.mdx
+++ b/content/docs/components/testimonial.mdx
@@ -8,7 +8,7 @@ description: A dynamic testimonial component that periodically updates the displ
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -55,7 +55,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/testimonial.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/text-hover-effect.mdx
+++ b/content/docs/components/text-hover-effect.mdx
@@ -8,7 +8,7 @@ description: Highligts the text on hover
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-  <Tabs defaultValue="manual">
+  <CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -50,7 +50,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/text-hover-effect.json
 
   </TabsContent>
 
-  </Tabs>
+  </CodeTabs>
 
 ### Props
 

--- a/content/docs/components/text-rollup-effect.mdx
+++ b/content/docs/components/text-rollup-effect.mdx
@@ -8,7 +8,7 @@ description: A rollup effect for your texts
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
   <TabsList>
     <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -49,7 +49,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/text-rollup-effect.json
 
   </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/text-slider.mdx
+++ b/content/docs/components/text-slider.mdx
@@ -10,7 +10,7 @@ links:
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -74,7 +74,7 @@ npx shadcn@latest add https://ui.unizoy.com/r/text-slider.json
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/content/docs/components/typewriter.mdx
+++ b/content/docs/components/typewriter.mdx
@@ -10,7 +10,7 @@ links:
   className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
 />
 
-<Tabs defaultValue="manual">
+<CodeTabs>
 
 <TabsList>
   <TabsTrigger value="manual">Manual</TabsTrigger>
@@ -110,7 +110,7 @@ export function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]) {
 
 </TabsContent>
 
-</Tabs>
+</CodeTabs>
 
 ### Props
 

--- a/hooks/use-config.ts
+++ b/hooks/use-config.ts
@@ -9,6 +9,7 @@ type Config = {
   theme: BaseColor["name"]
   radius: number
   packageManager: "npm" | "yarn" | "pnpm" | "bun"
+  installationType: "manual" | "cli"
 }
 
 const configAtom = atomWithStorage<Config>("config", {
@@ -16,6 +17,7 @@ const configAtom = atomWithStorage<Config>("config", {
   theme: "zinc",
   radius: 0.5,
   packageManager: "pnpm",
+  installationType: "manual"
 })
 
 export function useConfig() {


### PR DESCRIPTION
Problem:
Switching the `packageManager` in the CLI section unintentionally reset the `installationType` to "manual", causing confusion and disrupting the workflow.

https://github.com/user-attachments/assets/f8faa336-2393-41c4-bb19-10c97d1ecf54

Solution:
Implemented persistent state management for the `installationType` (manual or CLI). Now, updating the `packageManager` in the CLI section no longer resets the `installationType`, ensuring the user’s selection is preserved across updates.

https://github.com/user-attachments/assets/e04298d1-bd69-4b94-a2ff-d3b8cba98744

